### PR TITLE
Make SetMethod slice to zero before appending

### DIFF
--- a/header.go
+++ b/header.go
@@ -465,7 +465,7 @@ func (h *RequestHeader) Method() []byte {
 
 // SetMethod sets HTTP request method.
 func (h *RequestHeader) SetMethod(method string) {
-	h.method = append(h.method, method...)
+	h.method = append(h.method[:0], method...)
 }
 
 // SetMethodBytes sets HTTP request method.


### PR DESCRIPTION
`SetMethod` appended directly to the `h.method` slice without setting its
length to zero, so multiple calls would create an unexpected value.